### PR TITLE
feat: add `no-unsanitized` plugin to base ESLint config

### DIFF
--- a/eslint/base/index.js
+++ b/eslint/base/index.js
@@ -10,7 +10,7 @@ module.exports = {
     },
   },
   plugins: ['prettier'],
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:no-unsanitized/DOM'],
   env: {
     es6: true,
   },

--- a/eslint/base/package.json
+++ b/eslint/base/package.json
@@ -11,6 +11,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-no-unsanitized": "^3.1.0",
     "eslint-plugin-prettier": "^3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,6 +3106,11 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
+eslint-plugin-no-unsanitized@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-3.1.0.tgz#c86cdd13d22bb52882eeccbd8da5da092f7c6c9c"
+  integrity sha512-4gOd6Genbs1iN2rk+Duw/AZHglBvl6htbZZyDPUX7YdjWSu1D/iOGq7EtomDZ6VjzHKRo32042JciX+PPDrZgQ==
+
 eslint-plugin-node@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz#365944bb0804c5d1d501182a9bc41a0ffefed726"


### PR DESCRIPTION
This ESLint plugin should help us catch instances where we're potentially inserting unsafe HTML into our DOM that opens us up to security vulnerabilities.

More details: https://github.com/mozilla/eslint-plugin-no-unsanitized

Part of [ch35733]