### PR TITLE
test: increase timeout to 30 seconds

### DIFF
--- a/generator-lint-config/__tests__/app/mono-repo-support.js
+++ b/generator-lint-config/__tests__/app/mono-repo-support.js
@@ -5,7 +5,8 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const fs = require('fs-extra');
 
-const TIMEOUT_MS = 10000;
+const seconds = (ms) => ms * 1000;
+const TIMEOUT_MS = seconds(30);
 
 beforeAll(() => {
   return helpers


### PR DESCRIPTION
Increases the timeout for the `yarn install` test to avoid failing.

Closes #234

