### PR TITLE
fix(react): adding babel jsx syntax for react lint

### DIFF
--- a/eslint/react/__tests__/react-config.js
+++ b/eslint/react/__tests__/react-config.js
@@ -9,11 +9,6 @@ test('it uses the right basic configuration', async () => {
     path.resolve(__dirname, './fixtures/normal-project/index.js')
   );
 
-  expect(config.parserOptions.ecmaFeatures).toEqual({
-    jsx: true,
-    legacyDecorators: true,
-  });
-
   expect(config.rules['prettier/prettier']).toEqual(['error']);
 
   expect(config.settings).toEqual({
@@ -30,4 +25,22 @@ test('it uses the right test configuration', async () => {
   );
 
   expect(config.rules['react/jsx-props-no-spreading']).toEqual(['off']);
+});
+
+test('it configures JSX parsing', async () => {
+  const eslint = new ESLint({
+    overrideConfig: {
+      settings: {
+        react: {
+          // A warning is printed due to `react` not being a dependency if we leave the original `detect` setting
+          version: '16',
+        },
+      },
+    },
+  });
+  const [result] = await eslint.lintFiles(
+    path.resolve(__dirname, './fixtures/normal-project/index.js')
+  );
+
+  expect(result.messages).toEqual([]);
 });

--- a/eslint/react/index.js
+++ b/eslint/react/index.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
+    babelOptions: {
+      plugins: [require.resolve('@babel/plugin-syntax-jsx')],
     },
   },
   extends: ['plugin:react/recommended'],

--- a/eslint/react/package.json
+++ b/eslint/react/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
+    "@babel/plugin-syntax-jsx": "^7.12.13",
     "eslint-plugin-react": "^7.23.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,6 +381,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-jsx@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz#044fb81ebad6698fe62c478875575bcbb9b70f15"
+  integrity sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.8.3.tgz#3995d7d7ffff432f6ddc742b47e730c054599897"


### PR DESCRIPTION
Seems like JSX syntax isn't enabled, adding the babel JSX syntax looks to resolve this error. 

Error:
<img width="823" alt="Screenshot 2021-05-13 at 14 56 12" src="https://user-images.githubusercontent.com/17278432/118135845-6229c580-b3fb-11eb-8141-b9a888acd715.png">
